### PR TITLE
Fixed crash happening after package name was changed to ".crazyfliecontrol2".

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -36,7 +36,7 @@
                 android:resource="@xml/device_filter" />
         </activity>
         <activity android:name="se.bitcraze.crazyfliecontrol.prefs.PreferencesActivity">
-            <meta-data android:value="se.bitcraze.crazyfliecontrol.MainActivity" android:name="android.support.PARENT_ACTIVITY"/>
+            <meta-data android:value="se.bitcraze.crazyfliecontrol2.MainActivity" android:name="android.support.PARENT_ACTIVITY"/>
         </activity>
     </application>
 


### PR DESCRIPTION
The crash can be reproduced by clicking navigation back button at settings window.
