### PR TITLE
Option to have the onscreen throttle stick spring all the way down.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,4 +56,5 @@ android {
 
 dependencies {
     compile 'com.android.support:support-v4:21.0.2'
+    compile files('libs/slf4j-android-1.6.1-RC1.jar')
 }

--- a/crazyflie-android-client.iml
+++ b/crazyflie-android-client.iml
@@ -16,6 +16,7 @@
         <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
         <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugTestSources" />
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res" />
       </configuration>
     </facet>
   </component>
@@ -75,11 +76,13 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="support-annotations-21.0.2" level="project" />
     <orderEntry type="library" exported="" name="support-v4-21.0.2" level="project" />
+    <orderEntry type="library" exported="" name="slf4j-android-1.6.1-RC1" level="project" />
   </component>
 </module>
 

--- a/crazyflie-android-client.iml
+++ b/crazyflie-android-client.iml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android-gradle" name="Android-Gradle">
+      <configuration>
+        <option name="GRADLE_PROJECT_PATH" value=":" />
+      </configuration>
+    </facet>
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="SELECTED_BUILD_VARIANT" value="debug" />
+        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
+        <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
+        <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
+        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugTest" />
+        <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
+        <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugTestSources" />
+        <option name="ALLOW_USER_CONFIGURATION" value="false" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/test/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/test/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/test/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/test/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/test/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/test/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/coverage-instrumented-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/libs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndk" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/proguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+    </content>
+    <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" exported="" name="support-annotations-21.0.2" level="project" />
+    <orderEntry type="library" exported="" name="support-v4-21.0.2" level="project" />
+  </component>
+</module>
+

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -109,5 +109,7 @@
     <string name="preferences_category_bluetooth">Bluetooth Settings</string>
     <string name="preferences_ble_latency_fix">Bluetooth latency workaround</string>
     <string name="preferences_ble_latency_fix_sumary">Check if you experience big latency (seconds of latency).</string>
+    <string name="preferences_touch_thrust_full_travel">Touchscreen thrust full travel</string>
+    <string name="preferences_touch_thrust_full_travel_summary">On the touch controller, make the joystick controlling thrust return to the bottom instead of the center.</string>
 
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -212,7 +212,7 @@
             android:title="@string/preferences_use_gyro_bool_title" />
 
         <CheckBoxPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="pref_touch_thrust_full_travel"
             android:summary="@string/preferences_touch_thrust_full_travel_summary"
             android:title="@string/preferences_touch_thrust_full_travel" />

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -211,6 +211,12 @@
             android:summaryOn="@string/preferences_use_gyro_bool_summary_on"
             android:title="@string/preferences_use_gyro_bool_title" />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_touch_thrust_full_travel"
+            android:summary="@string/preferences_touch_thrust_full_travel_summary"
+            android:title="@string/preferences_touch_thrust_full_travel" />
+
     </PreferenceScreen>
 
     <!-- App settings -->

--- a/src/com/MobileAnarchy/Android/Widgets/Joystick/DualJoystickView.java
+++ b/src/com/MobileAnarchy/Android/Widgets/Joystick/DualJoystickView.java
@@ -106,6 +106,18 @@ public class DualJoystickView extends LinearLayout {
         stickR.setAutoReturnToCenter(right);
     }
 
+    public void setAutoReturnMode(int left, int right) {
+        stickL.setAutoReturnMode(left);
+        stickR.setAutoReturnMode(right);
+    }
+
+    public void autoReturn(boolean immediate)
+    {
+        stickL.autoReturn(immediate);
+        stickR.autoReturn(immediate);
+    }
+
+
     public void setOnJoystickMovedListener(JoystickMovedListener left, JoystickMovedListener right) {
         stickL.setOnJoystickMovedListener(left);
         stickR.setOnJoystickMovedListener(right);

--- a/src/com/MobileAnarchy/Android/Widgets/Joystick/JoystickView.java
+++ b/src/com/MobileAnarchy/Android/Widgets/Joystick/JoystickView.java
@@ -265,7 +265,10 @@ public class JoystickView extends View {
         bgRadius = dimX / 2 - innerPadding;
         handleRadius = (int) (d * 0.20);
         handleInnerBoundaries = handleRadius;
+        float oldMovementRadius = movementRadius;
         movementRadius = Math.min(cX, cY) - handleInnerBoundaries;
+        if(oldMovementRadius != movementRadius)
+            autoReturn(true);
     }
 
     private int measure(int measureSpec) {

--- a/src/se/bitcraze/crazyfliecontrol/controller/Controls.java
+++ b/src/se/bitcraze/crazyfliecontrol/controller/Controls.java
@@ -64,6 +64,7 @@ public class Controls {
     private int mControllerType;
     private String mControllerTypeDefaultValue;
     private boolean mUseGyro;
+    private boolean mTouchThrustFullTravel;
 
     private String mModeDefaultValue;
     private String mDeadzoneDefaultValue;
@@ -111,6 +112,7 @@ public class Controls {
 
         this.mControllerType = Integer.parseInt(mPreferences.getString(PreferencesActivity.KEY_PREF_CONTROLLER, mControllerTypeDefaultValue));
         this.mUseGyro = mPreferences.getBoolean(PreferencesActivity.KEY_PREF_USE_GYRO_BOOL, false);
+        this.mTouchThrustFullTravel = mPreferences.getBoolean(PreferencesActivity.KEY_PREF_TOUCH_THRUST_FULL_TRAVEL, false);
 
         //Advanced flight control
         if (mPreferences.getBoolean(PreferencesActivity.KEY_PREF_AFC_BOOL, false)) {
@@ -205,6 +207,10 @@ public class Controls {
 
     public boolean isUseGyro() {
         return mUseGyro;
+    }
+
+    public boolean isTouchThrustFullTravel() {
+        return mTouchThrustFullTravel;
     }
 
     public float getRightAnalog_X() {

--- a/src/se/bitcraze/crazyfliecontrol/controller/Controls.java
+++ b/src/se/bitcraze/crazyfliecontrol/controller/Controls.java
@@ -112,7 +112,7 @@ public class Controls {
 
         this.mControllerType = Integer.parseInt(mPreferences.getString(PreferencesActivity.KEY_PREF_CONTROLLER, mControllerTypeDefaultValue));
         this.mUseGyro = mPreferences.getBoolean(PreferencesActivity.KEY_PREF_USE_GYRO_BOOL, false);
-        this.mTouchThrustFullTravel = mPreferences.getBoolean(PreferencesActivity.KEY_PREF_TOUCH_THRUST_FULL_TRAVEL, false);
+        this.mTouchThrustFullTravel = mPreferences.getBoolean(PreferencesActivity.KEY_PREF_TOUCH_THRUST_FULL_TRAVEL, true);
 
         //Advanced flight control
         if (mPreferences.getBoolean(PreferencesActivity.KEY_PREF_AFC_BOOL, false)) {

--- a/src/se/bitcraze/crazyfliecontrol/prefs/PreferencesActivity.java
+++ b/src/se/bitcraze/crazyfliecontrol/prefs/PreferencesActivity.java
@@ -82,6 +82,7 @@ public class PreferencesActivity extends PreferenceActivity {
     public static final String KEY_PREF_CONTROLLER = "pref_controller";
     public static final String KEY_PREF_USE_GYRO_BOOL = "pref_use_gyro_bool";
     public static final String KEY_PREF_BTN_SCREEN = "pref_btn_screen";
+    public static final String KEY_PREF_TOUCH_THRUST_FULL_TRAVEL = "pref_touch_thrust_full_travel";
     public static final String KEY_PREF_RIGHT_ANALOG_X_AXIS = "pref_right_analog_x_axis";
     public static final String KEY_PREF_RIGHT_ANALOG_Y_AXIS = "pref_right_analog_y_axis";
     public static final String KEY_PREF_LEFT_ANALOG_X_AXIS = "pref_left_analog_x_axis";


### PR DESCRIPTION
When I was using the Android app to fly the Crazyflie 2, the throttle control seemed very touchy - I think just because there's so little distance between zero throttle in the center and full throttle at the top.  This implements an optional setting to have whichever joystick is associated with throttle spring all the way to the bottom when you let go, so you can use the full range of travel and get finer control.

It also includes some project file stuff to get it working with Android Studio.