### PR TITLE
Fix Split Package sending

### DIFF
--- a/src/se/bitcraze/crazyfliecontrol/ble/BleLink.java
+++ b/src/se/bitcraze/crazyfliecontrol/ble/BleLink.java
@@ -414,7 +414,7 @@ public class BleLink extends CrtpDriver {
         // controlbyte + payload (rest)
         byte[] secondPacket = new byte[20];
         secondPacket[0] = new ControlByte(false, pid, 0).toByte();
-        System.arraycopy(packet.getPayload(),19, secondPacket, 1, packet.getPayload().length-19);
+        System.arraycopy(packet.getPayload(),18 , secondPacket, 1, packet.getPayload().length-19);
         // send second packet
         mContext.runOnUiThread(new SendBlePacket(secondPacket, mCrtpUpChar));
         pid = (pid+1)%4;


### PR DESCRIPTION
Split package skipped the byte with index 18 in the payload. Package 1 send index 0-17, and package 2 started at 19, skipping byte 18 in the process. Made package 2 start at 18 instead.